### PR TITLE
Added Builder pattern for JokeRequest

### DIFF
--- a/src/main/java/com/github/codeboy/jokes4j/api/JokeRequest.java
+++ b/src/main/java/com/github/codeboy/jokes4j/api/JokeRequest.java
@@ -117,4 +117,122 @@ public class JokeRequest {
     public URL getURl() throws MalformedURLException {
         return new URL(generateUrl());
     }
+
+    /**
+     * A Builder Pattern for {@link JokeRequest}
+     */
+    public static class Builder {
+        private Category[] categories;
+        private Language language;
+        private Flag[] blackList;
+        private JokeType type;
+        private String searchString;
+        private int minId, maxId;
+        private int amount;
+        private boolean safeMode;
+
+        public Builder() {
+            type = JokeType.single;
+            safeMode = false;
+        }
+
+        /**
+         * Set the categories to be used in the request.
+         * @param categories The categories of the joke. Null will be considered as any.
+         * @return This builder instance for chaining.
+         */
+        public Builder categories(Category[] categories) {
+            this.categories = categories;
+            return this;
+        }
+
+        /**
+         * Set the language to be used in the request.
+         * @param language The language of the joke. Null will be considered as English.
+         * @return This builder instance for chaining.
+         */
+        public Builder language(Language language) {
+            this.language = language;
+            return this;
+        }
+
+        /**
+         * Set the flags to be blacklisted in the request.
+         * @param blackList An Array of flags to be blacklisted. Null will be considered as no blacklist.
+         * @return This builder instance for chaining.
+         */
+        public Builder blackList(Flag[] blackList) {
+            this.blackList = blackList;
+            return this;
+        }
+
+        /**
+         * Set the type of the joke.
+         * @param type The type of the joke. Null will be considered as both single and twopart.
+         * @return This builder instance for chaining.
+         */
+        public Builder type(JokeType type) {
+            this.type = type;
+            return this;
+        }
+
+        /**
+         * Set the search string to be used in the request.
+         * @param searchString A string that the joke resulting from the request must contain. Null will be considered as no search string.
+         * @return This builder instance for chaining.
+         */
+        public Builder searchString(String searchString) {
+            this.searchString = searchString;
+            return this;
+        }
+
+        /**
+         * Set the smallest joke id.
+         * @param minId The minimum id of the joke. 0 will be considered as no minimum.
+         * @return This builder instance for chaining.
+         */
+        public Builder minId(int minId) {
+            this.minId = minId;
+            return this;
+        }
+
+        /**
+         * Set the largest joke id.
+         * @param maxId The maximum id of the joke. 0 will be considered as no maximum.
+         * @return This builder instance for chaining.
+         */
+        public Builder maxId(int maxId) {
+            this.maxId = maxId;
+            return this;
+        }
+
+        /**
+         * Set the amount of jokes to be used in the request.
+         * @param amount The amount of jokes to be used. Everything below 1 will be considered as 1.
+         * @return This builder instance for chaining.
+         */
+        public Builder amount(int amount) {
+            this.amount = amount;
+            return this;
+        }
+
+        /**
+         * Set whether safe mode should be used in the request.
+         * @param safeMode True if the request should use safe mode. False if not.
+         * @return This builder instance for chaining.
+         */
+        public Builder safeMode(boolean safeMode) {
+            this.safeMode = safeMode;
+            return this;
+        }
+
+        /**
+         * Build the {@link JokeRequest} instance.
+         * @return The {@link JokeRequest} instance.
+         */
+        public JokeRequest build() {
+            return new JokeRequest(categories, language, blackList, type, searchString, minId, maxId, amount, safeMode);
+        }
+    }
+
 }


### PR DESCRIPTION
Added JokeRequest#Builder to the JokeRequest class for cleaner object creation as well as nicer code formatting at creation time.

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>